### PR TITLE
fix bug with cache objects changed in react

### DIFF
--- a/src/share.ts
+++ b/src/share.ts
@@ -1,24 +1,54 @@
 import { useEffect, useReducer, useRef } from 'react';
 import { effect, stop, ReactiveEffect } from '@vue/reactivity';
 
+type TVueEffectParameters = Parameters<typeof effect>;
+
 export const useForceUpdate = () => {
   const [, forceUpdate] = useReducer(s => s + 1, 0);
   return forceUpdate;
 };
 
-export const useEffection = (...effectArgs: Parameters<typeof effect>) => {
+export const useEffection = (
+  fn: TVueEffectParameters[0], 
+  options?: TVueEffectParameters[1], 
+  changes?: any[]
+) => {
   // 用一个ref存储effection
   // effect函数只需要初始化执行一遍
-  const effectionRef = useRef<ReactiveEffect>();
+  const effectionRef = useRef<{
+    effect: ReactiveEffect,
+    changes: any[] | undefined
+  }>();
   if (!effectionRef.current) {
-    effectionRef.current = effect(...effectArgs);
+    effectionRef.current = {
+      effect: effect(fn, options),
+      changes: changes,
+    };
+  } else if (changes && changes.length && compare(effectionRef.current.changes, changes)) {
+    // 当旧的变化数据与新的变化数据的索引数据上的不一致
+    // 我们需要销毁之前的effect
+    stop(effectionRef.current.effect);
+    // 重新创建新的effect
+    effectionRef.current = {
+      effect: effect(fn, options),
+      changes: changes,
+    };
   }
 
   // 卸载组件后取消effect
   const stopEffect = () => {
-    stop(effectionRef.current!);
+    stop(effectionRef.current?.effect!);
   };
   useEffect(() => stopEffect, []);
 
-  return effectionRef.current
+  return effectionRef.current.effect;
 };
+
+function compare(oldChanges: any[] | undefined, newChanges: any[]) {
+  oldChanges = oldChanges || [];
+  if (oldChanges.length !== newChanges.length) return true;
+  for (let i = 0; i < newChanges.length; i++) {
+    if (oldChanges[i] !== newChanges[i]) return true;
+  }
+  return false;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -19,7 +19,7 @@ const useStoreContext = () => {
  * 在组件中读取全局状态
  * 需要通过传入的函数收集依赖
  */
-export const useStore = <T, S>(selector: Selector<T, S>): S => {
+export const useStore = <T, S>(selector: Selector<T, S>, changes?: any[]): S => {
   const forceUpdate = useForceUpdate();
   const store = useStoreContext();
 
@@ -29,7 +29,7 @@ export const useStore = <T, S>(selector: Selector<T, S>): S => {
       forceUpdate();
     },
     lazy: true,
-  });
+  }, changes);
 
   const value = effection();
   return value;


### PR DESCRIPTION
在 [TypeClient](https://github.com/flowxjs/TypeClient/commit/8ca49b4ce11985a9eed40ef1f0a7148d343e5ecf) 这个项目的bugfix阶段，我们发现你的逻辑并不严谨，会导致很多react组件渲染时候出现问题，所以，我们进行了修复并且同步给您。希望您能认真考虑后确认是否合并这个PR。

合并后，您的代码可能会有所变化，但是我们也兼容了老的写法：

```ts
const countState = useStore((store: Store) => ({
    count: store.count,
  }), [object1, object2, ...])
```
> 意思：当`[object1, object2]`数据有变化的时候，程序将自动stop销毁掉之前的effect引用，使用新的effect作为这次的引用。这类似于`useMemo`一样，之后第二个参数变化的时候，它的值才会变。

它的interface变为：

```ts
<T, S>(selector: Selector<T, S>, changes?: any[]): S;
```